### PR TITLE
refactor: HTML div.window becomes ul.projects > li.window

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="https://unpkg.com/@sakun/system.css" />
     <style>
       .window { width: 640px }
+      ol.projects { margin-block-start: 0; margin-inline-start: 0; padding: 0 }
     </style>
   </head>
   <body>    
@@ -44,101 +45,103 @@
     </div>
     
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1996: Mac Reviews Digest</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./mrd/index.html"><img src="./thumbs/mrd.gif"/></a>
-    </div>
+    <ol class="projects">
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1996: Mac Reviews Digest</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./mrd/index.html"><img src="./thumbs/mrd.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1996: Poor Naming Choices</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-1996/index.html"><img src="./thumbs/home-1996.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1996: Poor Naming Choices</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-1996/index.html"><img src="./thumbs/home-1996.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1997: Dancing Mongoose</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-1997/index.html"><img src="./thumbs/home-1997.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1997: Dancing Mongoose</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-1997/index.html"><img src="./thumbs/home-1997.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1997: Hope Station</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./hope/index.html"><img src="./thumbs/hope.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1997: Hope Station</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./hope/index.html"><img src="./thumbs/hope.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1997: Cornerstone Festival</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./cstone/"><img src="./thumbs/cstone.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1997: Cornerstone Festival</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./cstone/"><img src="./thumbs/cstone.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1997: Hope Station: Phoenix</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./phoenix/index.html"><img src="./thumbs/phoenix.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1997: Hope Station: Phoenix</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./phoenix/index.html"><img src="./thumbs/phoenix.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1998: Emo/Grunge Phase</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-1998/index.html"><img src="./thumbs/home-1998.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1998: Emo/Grunge Phase</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-1998/index.html"><img src="./thumbs/home-1998.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">1996: Mystery Meat Navigation</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-1999/index.html"><img src="./thumbs/home-1999.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">1996: Mystery Meat Navigation</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-1999/index.html"><img src="./thumbs/home-1999.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">2000: What If Just No Content</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-2000/index.html"><img src="./thumbs/home-2000.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">2000: What If Just No Content</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-2000/index.html"><img src="./thumbs/home-2000.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">2001: Who Needs Accessibility?</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-2001.jpeg/"><img src="./thumbs/home-2001.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">2001: Who Needs Accessibility?</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-2001.jpeg/"><img src="./thumbs/home-2001.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">2002: Still With The Tables</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-2002/index.html"><img src="./thumbs/home-2002.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">2002: Still With The Tables</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-2002/index.html"><img src="./thumbs/home-2002.gif"/></a>
+      </li>
 
-    <div class="window">
-      <div class="title-bar">
-        <h1 class="title">2003: Just A Test Pattern</h1>
-      </div>
-      <div class="separator"></div>
-      <a href="./home-2003/index.html"><img src="./thumbs/home-2003.gif"/></a>
-    </div>
+      <li class="window">
+        <div class="title-bar">
+          <h1 class="title">2003: Just A Test Pattern</h1>
+        </div>
+        <div class="separator"></div>
+        <a href="./home-2003/index.html"><img src="./thumbs/home-2003.gif"/></a>
+      </li>
+    </ol
 
   </body>
 </html>


### PR DESCRIPTION
Added CSS to override the list styling
Looks the same on firefox, chrome, edge, safari

Tested using `python3 -m http.server`

The idea is that the div's don't really mean much, so I think having list items is semantic.
I chose `ol` simply because the list is directional 1996 -> 2001